### PR TITLE
Update rubocop.yml - replace 'Style/TrailingCommaInLiteral'

### DIFF
--- a/dot/rubocop.yml
+++ b/dot/rubocop.yml
@@ -371,8 +371,18 @@ Style/TrailingCommaInArguments:
     - no_comma
   Enabled: true
 
-Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in array and hash literals.'
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  EnforcedStyleForMultiline: comma
+  SupportedStyles:
+    - comma
+    - consistent_comma
+    - no_comma
+  Enabled: true
+
+  Style/TrailingCommaInInHashLiteral:
+  Description: 'Checks for trailing comma in hash literals.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   EnforcedStyleForMultiline: comma
   SupportedStyles:
@@ -651,7 +661,10 @@ Style/StringLiterals:
 Style/Documentation:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+  
+Style/TrailingCommaInHashLiteral:
   Enabled: false
 
 Style/TrailingCommaInArguments:


### PR DESCRIPTION
The 'Style/TrailingCommaInLiteral:' cop has been replaced. It has been split into 2 separate and more specific cops; one specifically for Array Literals and one for Hash Literals. 
      `Style/TrailingCommaInArrayLiteral:`
      `Style/TrailingCommaInHashLiteral:`

An "Error:' message is triggered constantly and repeatedly because of the discrepancy between the new rubocop distinction and the old rubocop.yml config. 

An update would be very helpful, as it's especially confusing, perhaps even daunting, for newer students whom likely have little to no experience with Rubocop.